### PR TITLE
[FIX] Dockerfile: Configure the locate using the localte en_US.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:14.04
 MAINTAINER Jesus Zapata <jesus@vauxoo.com>
 
+# Configure locale
+RUN locale-gen en_US.UTF-8; update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8;
+RUN echo 'LANG="en_US.UTF-8"' > /etc/default/locale
+
 # Install OpenSSH
 RUN apt-get update && apt-get upgrade -y && apt-get install -y openssh-server
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Docker container for only openssh-server
 
 `SSH_KEY` The ssh-key allowed to login to the ssh server
 
+`SSH_DEPENDENCIES` To install the another apt-get dependencies
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 set -e
 
 if ! grep ${SSH_USER} /etc/passwd ; then
+    # Install dependencies
+    apt-get install -y ${SSH_DEPENDENCIES}
+
 	# Create the user with ssh access
 	useradd -d "/home/${SSH_USER}" -m -s "/bin/bash" "${SSH_USER}"
 	mkdir -p /home/${SSH_USER}/.ssh/


### PR DESCRIPTION
To avoid the following error when the user log in over ssh

![image](https://user-images.githubusercontent.com/1387970/28653209-4e31057a-725a-11e7-8625-f400206cb105.png)


"-bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)"