### PR TITLE
[IMP] entrypoint.sh: Now the SSH_KEY can be receives many ssh's

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Docker container for only openssh-server
 
 `SSH_USER` The name of the user that can log in
 
-`SSH_KEY` The ssh-key allowed to login to the ssh server
+`SSH_KEY` The ssh-key allowed to login to the ssh server. You can provide many ssh keys separated with coma
 
 `SSH_DEPENDENCIES` To install the another apt-get dependencies
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,11 @@ if ! grep ${SSH_USER} /etc/passwd ; then
 
 	# Copy the authorized_keys
 	touch /home/${SSH_USER}/.ssh/authorized_keys
-	echo "$SSH_KEY" >> /home/${SSH_USER}/.ssh/authorized_keys
+	IFS=',' read -a keys <<< "${SSH_KEY}"
+    	for key in "${keys[@]}"
+    	do
+		echo "$key" >> /home/${SSH_USER}/.ssh/authorized_keys
+    	done
 	chmod 600 /home/${SSH_USER}/.ssh/authorized_keys
 	
 	# Change the owner of the ssh folder


### PR DESCRIPTION
Now the environment variable  `SSH_KEY` can be separated with coma

`SSH_KEY=uno,dos`

![image](https://user-images.githubusercontent.com/1387970/28981238-f4887ce4-791e-11e7-8ddc-b88434e1595f.png)

