### PR TITLE
[FIX] entrypoint.sh: Update the apt.get before the install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN locale-gen en_US.UTF-8; update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 
 RUN echo 'LANG="en_US.UTF-8"' > /etc/default/locale
 
 # Install OpenSSH
-RUN apt-get update && apt-get upgrade -y && apt-get install -y openssh-server
+RUN apt-get update && apt-get upgrade -y && apt-get install -y openssh-server git
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Before the `apt-get install` now it runs the `apt-get update`

I build this imagen using the follow command `docker build -t docker-ssh .` and the build ran well

![image](https://user-images.githubusercontent.com/1387970/29522596-b7e97324-8657-11e7-88d4-d8c8c0b45880.png)

Fix https://github.com/Vauxoo/docker-ssh/issues/4